### PR TITLE
Add TagInputWidget demo to test site

### DIFF
--- a/bfe_test/template/templates/widgets_demo.html
+++ b/bfe_test/template/templates/widgets_demo.html
@@ -51,6 +51,10 @@
             {{ datepicker.render|safe }}
         </section>
         <section>
+            <h3>Tag Input</h3>
+            {{ tag_input.render|safe }}
+        </section>
+        <section>
             <h3>Text Editor</h3>
             {{ text_editor.render|safe }}
         </section>

--- a/bfe_test/template/views.py
+++ b/bfe_test/template/views.py
@@ -8,14 +8,15 @@ from byefrontend.widgets import (
     TableWidget, PopOut, TinyThumbnailWidget,
     TitleWidget, HyperlinkWidget, NavBarWidget, SecretToggleCharWidget,
     FileUploadWidget, InlineGroupWidget, TextEditorWidget, InlineFormWidget,
-    ParagraphWidget, DocumentLinkWidget, DocumentViewerWidget, DataFilterWidget
+    ParagraphWidget, DocumentLinkWidget, DocumentViewerWidget, DataFilterWidget,
+    TagInputWidget
 )
 from byefrontend.configs import (
     TableConfig, NavBarConfig, HyperlinkConfig, FileUploadConfig,
     SecretToggleConfig, PopOutConfig, ThumbnailConfig, TitleConfig,
     RadioGroupConfig, CheckBoxConfig, LabelConfig, InlineGroupConfig,
     DropdownConfig, DatePickerConfig, InlineFormConfig, ParagraphConfig, DocumentLinkConfig,
-    DocumentViewerConfig, DataFilterConfig
+    DocumentViewerConfig, DataFilterConfig, TagInputConfig
 )
 
 from byefrontend.storage import get_storage
@@ -226,6 +227,13 @@ def widgets_demo(request):
         )
     )
 
+    tag_input = TagInputWidget(
+        config=TagInputConfig(
+            placeholder="Add tags",
+            suggestions=("alpha", "beta", "gamma", "delta"),
+        )
+    )
+
     lorem_ipsum = """
 Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 Suspendisse gravida viverra magna sed consequat.
@@ -317,6 +325,7 @@ Vestibulum nec iaculis arcu. Integer vel elit sed tortor mattis maximus non quis
         "inlinegroup": inlinegroup,
         "datepicker": datepicker,
         "dropdown": dropdown,
+        "tag_input": tag_input,
         "text_editor": text_editor,
         "bfe_form": bfe_form,
         "inline_form": inline_form,


### PR DESCRIPTION
## Summary
- showcase TagInputWidget in the widgets demo page
- load TagInputWidget and configuration in demo views

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879909d74c8832d8410989f9c507f53