### PR TITLE
Fix TagInputWidget value parsing

### DIFF
--- a/src/byefrontend/form_fields.py
+++ b/src/byefrontend/form_fields.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from django import forms
+from typing import Iterable
+
+class TagListField(forms.Field):
+    """Field that parses comma separated tags into a list of strings."""
+
+    def to_python(self, value):
+        if not value:
+            return []
+        if isinstance(value, str):
+            return [t.strip() for t in value.split(',') if t.strip()]
+        if isinstance(value, Iterable):
+            tags: list[str] = []
+            for val in value:
+                if not val:
+                    continue
+                tags.extend(t.strip() for t in str(val).split(',') if t.strip())
+            return tags
+        return [str(value)]

--- a/src/byefrontend/tests.py
+++ b/src/byefrontend/tests.py
@@ -1,2 +1,14 @@
 from django.test import TestCase
 
+from .widgets import BFEFormWidget
+from .configs import FormConfig, TagInputConfig
+
+
+class TagInputWidgetTests(TestCase):
+    def test_cleaned_data_is_list_of_tags(self):
+        cfg = FormConfig(children={"tags": TagInputConfig()})
+        form = BFEFormWidget(config=cfg, data={"tags": "one,two, three"})
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data["tags"], ["one", "two", "three"])
+
+

--- a/src/byefrontend/widgets/form.py
+++ b/src/byefrontend/widgets/form.py
@@ -8,6 +8,7 @@ from .base import BFEBaseWidget
 from ..builders import build_children, ChildBuilderRegistry
 from ..configs.form import FormConfig
 from ..widgets.file_upload import FileUploadWidget
+from ..form_fields import TagListField
 from logging import getLogger
 log = getLogger(__name__)
 
@@ -20,6 +21,7 @@ WIDGET_TO_FIELD = {
     "CheckBoxWidget":   forms.BooleanField,
     "RadioGroupWidget": forms.ChoiceField,
     "FileUploadWidget": forms.FileField,
+    "TagInputWidget": TagListField,
     "TextEditorWidget": forms.CharField,
 }
 


### PR DESCRIPTION
## Summary
- create `TagListField` form field that produces a list of tags
- connect `TagInputWidget` to `TagListField` so forms return a list
- add regression test

## Testing
- `pytest -q` *(fails: no tests collected)*
- `python bfe_test/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6879b403cf3c832dbe6f975ff6b2cdfb