### PR TITLE
Fix server-supplied tags deletion

### DIFF
--- a/src/byefrontend/static/byefrontend/js/tag_input.js
+++ b/src/byefrontend/static/byefrontend/js/tag_input.js
@@ -70,7 +70,10 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     // initialise from existing hidden value
+    // remove any server-rendered tags so we can rebuild them with
+    // proper event handlers attached
     const initial = hidden.value.split(',').map(t => t.trim()).filter(t => t);
+    wrapper.querySelectorAll('.bfe-tag').forEach(span => span.remove());
     initial.forEach(addTag);
   }
 });


### PR DESCRIPTION
## Summary
- ensure TagInputWidget removes server-rendered tags and rebuilds them with JS

## Testing
- `python bfe_test/manage.py test -v 2` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6879b9ed7ef0832d88682f107334384a