### PR TITLE
Add label support for FileUploadWidget

### DIFF
--- a/src/byefrontend/configs/file_upload.py
+++ b/src/byefrontend/configs/file_upload.py
@@ -11,7 +11,12 @@ class FileUploadConfig(WidgetConfig):
     """
     Immutable configuration for :class:`FileUploadWidget`.
 
-    Tweak it via `dataclasses.replace` *or* the shortcut
+    - ``label``      – optional text displayed next to the upload element
+                        (ignored when ``is_in_form`` is ``True``)
+    - ``is_in_form`` – suppress the outer ``<label>`` when embedded inside a
+                        Django ``Form`` or ``InlineFormWidget``.
+
+    Tweak it via ``dataclasses.replace`` *or* the shortcut
     ::
         from byefrontend.configs import tweak, FileUploadConfig
         cfg = tweak(FileUploadConfig(), auto_upload=True)
@@ -24,6 +29,7 @@ class FileUploadConfig(WidgetConfig):
     auto_upload: bool = False
     can_upload_multiple_files: bool = True
     inline_text: str = "Drop files here or click to upload."
+    is_in_form: bool = False
 
     # metadata columns shown in the JS table
     # Each mapping follows the legacy shape:

--- a/src/byefrontend/static/byefrontend/js/file_upload.js
+++ b/src/byefrontend/static/byefrontend/js/file_upload.js
@@ -7,7 +7,7 @@ document.addEventListener('DOMContentLoaded', function() {
         return;
     }
     const dropZone = widget.querySelector('#drop-zone');
-    const fileInput = widget.querySelector('#file-input');
+    const fileInput = widget.querySelector('input[type="file"]');
     const messages = widget.querySelector('#messages');
     const toUploadList = widget.querySelector('#to-upload-list tbody');
     const uploadedList = widget.querySelector('#uploaded-list tbody');


### PR DESCRIPTION
## Summary
- extend `FileUploadConfig` with `is_in_form` and document label behaviour
- render label in `FileUploadWidget` unless embedded in a form
- give multi-file upload inputs unique ids
- query file input dynamically in `file_upload.js`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c8288e344832d9e39c9677b78f790