### PR TITLE
Improve single-file upload styling

### DIFF
--- a/src/byefrontend/static/byefrontend/css/file_upload.css
+++ b/src/byefrontend/static/byefrontend/css/file_upload.css
@@ -136,6 +136,14 @@
 
 .file-upload-wrapper.bfe-card{border:0;padding:0}
 
+.file-upload-single input[type=file]{
+  display:none;
+}
+
+.file-upload-single #drop-zone{
+  cursor:pointer;
+}
+
 #drop-zone{
   font-size:1.1rem;
   padding:var(--gap-lg);

--- a/src/byefrontend/widgets/file_upload.py
+++ b/src/byefrontend/widgets/file_upload.py
@@ -62,7 +62,7 @@ class FileUploadWidget(BFEBaseWidget):
                 attrs=None, renderer=None, **__):
         input_id = f"{self.id}_input"
 
-        # single file - plain <input type="file"> that plays nicely inside Django forms
+        # single file - styled similarly to the multi-file variant but without JS
         if not self.cfg.can_upload_multiple_files:
             accept_attr = (
                 f' accept="{",".join(self.cfg.filetypes_accepted)}"'
@@ -70,10 +70,12 @@ class FileUploadWidget(BFEBaseWidget):
             )
             required_attr = " required" if self.cfg.required else ""
             input_html = (
-                f'<div id="{self.cfg.widget_html_id or self.id}" '
-                f'class="file-upload-wrapper file-upload-single">'
-                f'  <input type="file" id="{input_id}" '
+                f'<div id="{self.cfg.widget_html_id or self.id}"'
+                f' class="bfe-card file-upload-wrapper file-upload-single">'
+                f'  <label id="drop-zone" for="{input_id}">{self.cfg.inline_text}</label>'
+                f'  <input type="file" id="{input_id}"'
                 f'         name="{name or self.id}"{accept_attr}{required_attr}>'
+                f'  <div id="messages"></div>'
                 f'</div>'
             )
         else:


### PR DESCRIPTION
## Summary
- style single-file uploads to match multi-file look
- hide file input and use label as drop zone

## Testing
- `python bfe_test/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688c86e9819c832daae8f699c9e00295