### PR TITLE
Fix FileUploadWidget layout in InlineForm

### DIFF
--- a/src/byefrontend/widgets/file_upload.py
+++ b/src/byefrontend/widgets/file_upload.py
@@ -118,8 +118,12 @@ class FileUploadWidget(BFEBaseWidget):
             lbl_cfg = LabelConfig(text=self.cfg.label, html_for=input_id)
             label_html = LabelWidget(config=lbl_cfg, parent=self).render()
 
+        wrapper_style = ''
+        if self.cfg.is_in_form:
+            wrapper_style = ' style="flex-basis:100%;max-width:100%;"'
+
         return mark_safe(
-            f'<div class="text-input-wrapper">{label_html}{input_html}</div>'
+            f'<div class="text-input-wrapper"{wrapper_style}>{label_html}{input_html}</div>'
         )
 
     def _create_data_json(self) -> Mapping[str, object]:


### PR DESCRIPTION
## Summary
- avoid layout glitches when using FileUploadWidget inside InlineFormWidget

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c91176e94832d80182202f92650b9