### PR TITLE
Fix file upload styling in inline forms

### DIFF
--- a/src/byefrontend/static/byefrontend/css/file_upload.css
+++ b/src/byefrontend/static/byefrontend/css/file_upload.css
@@ -1,5 +1,8 @@
 
 #drop-zone {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
     border: 2px dashed var(--accent-color, #bbb);
     padding: 50px;
     text-align: center;
@@ -145,6 +148,9 @@
 }
 
 #drop-zone{
+  display:block;
+  width:100%;
+  box-sizing:border-box;
   font-size:1.1rem;
   padding:var(--gap-lg);
 }


### PR DESCRIPTION
## Summary
- ensure the file upload drop zone always spans the full width by making it a block element with box-sizing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c94cd2d90832d907af16fee4c2abc