### PR TITLE
Enable keyboard navigation for TagInput

### DIFF
--- a/src/byefrontend/configs/tag_input.py
+++ b/src/byefrontend/configs/tag_input.py
@@ -10,3 +10,4 @@ class TagInputConfig(WidgetConfig):
     placeholder: str | None = None
     suggestions: Sequence[str] = field(default_factory=tuple)
     is_in_form: bool = False
+    keyboard_nav: bool = True

--- a/src/byefrontend/static/byefrontend/css/tag_input.css
+++ b/src/byefrontend/static/byefrontend/css/tag_input.css
@@ -57,3 +57,7 @@
 .bfe-tag-suggestion:hover {
   background: var(--primary-color);
 }
+
+.bfe-tag-suggestion.active {
+  background: var(--primary-color);
+}

--- a/src/byefrontend/static/byefrontend/js/tag_input.js
+++ b/src/byefrontend/static/byefrontend/js/tag_input.js
@@ -8,6 +8,16 @@ document.addEventListener('DOMContentLoaded', () => {
     const hidden = wrapper.querySelector('input[type=hidden]');
     const dropdown = wrapper.querySelector('.bfe-tag-suggestions');
     const suggestions = JSON.parse(wrapper.dataset.suggestions || '[]');
+    const keyboardNav = wrapper.dataset.keyboardNav !== 'false';
+    let selectedIndex = -1;
+
+    const highlight = () => {
+      const items = dropdown.querySelectorAll('.bfe-tag-suggestion');
+      items.forEach((item, i) => {
+        if (i === selectedIndex) item.classList.add('active');
+        else item.classList.remove('active');
+      });
+    };
 
     const updateHidden = () => {
       const tags = Array.from(wrapper.querySelectorAll('.bfe-tag'))
@@ -50,14 +60,34 @@ document.addEventListener('DOMContentLoaded', () => {
         dropdown.appendChild(div);
       });
       dropdown.style.display = 'block';
+      selectedIndex = -1;
+      highlight();
     };
 
     const hideSuggestions = () => { dropdown.style.display = 'none'; };
 
     input.addEventListener('keydown', e => {
+      const items = dropdown.querySelectorAll('.bfe-tag-suggestion');
+      if (keyboardNav && dropdown.style.display === 'block') {
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          selectedIndex = (selectedIndex + 1) % items.length;
+          highlight();
+          return;
+        } else if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          selectedIndex = (selectedIndex - 1 + items.length) % items.length;
+          highlight();
+          return;
+        }
+      }
       if (e.key === 'Enter' || e.key === ',') {
         e.preventDefault();
-        addTag(input.value);
+        if (keyboardNav && dropdown.style.display === 'block' && selectedIndex >= 0) {
+          addTag(items[selectedIndex].textContent);
+        } else {
+          addTag(input.value);
+        }
       }
     });
 

--- a/src/byefrontend/widgets/tag_input.py
+++ b/src/byefrontend/widgets/tag_input.py
@@ -54,7 +54,8 @@ class TagInputWidget(BFEFormCompatibleWidget):
 
         wrapper = (
             f'<div id="{base_id}" class="bfe-tag-input-wrapper"'
-            f' data-suggestions="{html.escape(json.dumps(list(cfg.suggestions)))}">'
+            f' data-suggestions="{html.escape(json.dumps(list(cfg.suggestions)))}"'
+            f' data-keyboard-nav="{str(cfg.keyboard_nav).lower()}">' 
             f'{hidden_html}{tags_html}{input_html}{suggest_html}</div>'
         )
 


### PR DESCRIPTION
## Summary
- allow `TagInputConfig` to enable keyboard navigation
- render the new config to the DOM
- highlight suggestions via CSS
- add arrow/enter navigation logic in `tag_input.js`

## Testing
- `python bfe_test/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688c9af9c9fc832d9a09dbaff6dfa0d2