### PR TITLE
Allow customizing submit button text

### DIFF
--- a/src/byefrontend/configs/form.py
+++ b/src/byefrontend/configs/form.py
@@ -22,4 +22,5 @@ class FormConfig(WidgetConfig):
     csrf: bool = True
     multipart: bool = False
     prefix: str | None = None
+    submit_text: str = "Submit"
     children: Mapping[str, WidgetConfig] = field(default_factory=dict)

--- a/src/byefrontend/tests.py
+++ b/src/byefrontend/tests.py
@@ -12,3 +12,11 @@ class TagInputWidgetTests(TestCase):
         self.assertEqual(form.cleaned_data["tags"], ["one", "two", "three"])
 
 
+class FormWidgetSubmitTextTests(TestCase):
+    def test_submit_text_is_customizable(self):
+        cfg = FormConfig(children={}, submit_text="Send")
+        form = BFEFormWidget(config=cfg)
+        html = form.render()
+        self.assertIn("Send", html)
+
+

--- a/src/byefrontend/widgets/form.py
+++ b/src/byefrontend/widgets/form.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import itertools
+import html
 from typing import Any, Mapping
 from django import forms
 from django.utils.safestring import mark_safe
@@ -137,7 +138,10 @@ class BFEFormWidget(forms.Form, BFEBaseWidget):
         )
         errors_html = self._render_errors()
 
-        btn = '<button type="submit" class="bfe-btn">Submit</button>'
+        btn = (
+            f'<button type="submit" class="bfe-btn">'
+            f'{html.escape(cfg.submit_text)}</button>'
+        )
 
         return mark_safe(
             f'<form id="{self.id}" action="{cfg.action}" method="{cfg.method}"{enctype} '


### PR DESCRIPTION
## Summary
- support configurable text on BFEFormWidget submit buttons
- test that the submit text can be changed

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement django==5.1)*
- `python -m pytest -vvv` *(0 tests ran)*
- `python bfe_test/manage.py test ..` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_688cc36b983c832d98f8c6b0094c2923