### PR TITLE
Fix stretched inline submit buttons

### DIFF
--- a/src/byefrontend/static/byefrontend/css/root.css
+++ b/src/byefrontend/static/byefrontend/css/root.css
@@ -115,6 +115,13 @@ main {
   box-shadow: 0 2px 5px var(--hover-shadow);
 }
 
+/* keep submit buttons compact in inline forms */
+.bfe-inline-form { align-items: flex-start; }
+.bfe-inline-form .bfe-btn {
+  align-self: flex-start;
+  flex: 0 0 auto;
+}
+
 .bfe-paragraph {
     margin-bottom: var(--gap-md);
     color: var(--text-color);


### PR DESCRIPTION
## Summary
- keep inline form buttons from stretching to container height

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cc8f4f4bc832d905cd63c8d699970